### PR TITLE
fix(patch): [sc-5289] use unaligned memory by default

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -126,7 +126,7 @@ public struct ByteBuffer {
   ///   - allowReadingUnalignedBuffers: allow reading from unaligned buffer
   public init(
     bytes: [UInt8], 
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false)
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true)
   {
     var b = bytes
     _storage = Storage(count: bytes.count, alignment: alignment)
@@ -144,7 +144,7 @@ public struct ByteBuffer {
   ///   - allowReadingUnalignedBuffers: allow reading from unaligned buffer
   public init(
     data: Data, 
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false)
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true)
   {
     var b = data
     _storage = Storage(count: data.count, alignment: alignment)
@@ -176,7 +176,7 @@ public struct ByteBuffer {
   public init<Bytes: ContiguousBytes>(
     contiguousBytes: Bytes,
     count: Int, 
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false)
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true)
   {
     _storage = Storage(count: count, alignment: alignment)
     _writerSize = _storage.capacity
@@ -195,7 +195,7 @@ public struct ByteBuffer {
   public init(
     assumingMemoryBound memory: UnsafeMutableRawPointer,
     capacity: Int,
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false)
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true)
   {
     _storage = Storage(memory: memory, capacity: capacity, unowned: true)
     _writerSize = capacity
@@ -210,7 +210,7 @@ public struct ByteBuffer {
   init(
     memory: UnsafeMutableRawPointer, 
     count: Int,
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false)
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true)
   {
     _storage = Storage(count: count, alignment: alignment)
     _storage.copy(from: memory, count: count)
@@ -228,7 +228,7 @@ public struct ByteBuffer {
     memory: UnsafeMutableRawPointer,
     count: Int,
     removing removeBytes: Int,
-    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = false) 
+    allowReadingUnalignedBuffers allowUnalignedBuffers: Bool = true) 
   {
     _storage = Storage(count: count, alignment: alignment)
     _storage.copy(from: memory, count: count)


### PR DESCRIPTION
Thank you for submitting a PR!

Please delete this standard text once you've created your own description.

If you make changes to any of the code generators (`src/idl_gen*`) be sure to
[build](https://google.github.io/flatbuffers/flatbuffers_guide_building.html) your project, as it will generate code based on the changes. If necessary
the code generation script can be directly run (`scripts/generate_code.py`),
requires Python3. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the
[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html),
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

For any C++ changes, please make sure to run `sh scripts/clang-format-git.sh`

Include other details as appropriate.

Thanks!
